### PR TITLE
specify Net::HTTP::Persistent.new argument name

### DIFF
--- a/lib/pubcontrolclient.rb
+++ b/lib/pubcontrolclient.rb
@@ -35,7 +35,7 @@ class PubControlClient
     @auth_jwt_claim = nil
     @auth_jwt_key = nil
     @auth_bearer_key = nil
-    @http = Net::HTTP::Persistent.new @object_id.to_s
+    @http = Net::HTTP::Persistent.new name: @object_id.to_s
     @http.open_timeout = 10
     @http.read_timeout = 10
   end


### PR DESCRIPTION
Fixes:
```
/usr/local/lib/ruby/gems/3.2.0/gems/net-http-persistent-4.0.2/lib/net/http/persistent.rb:478:in `initialize': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from /Users/jkarneges/src/fanout/ruby-pubcontrol/lib/pubcontrolclient.rb:38:in `new'
```